### PR TITLE
fix(client): bumped node version in dockerfile

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,1 +1,1 @@
-node_modules
+node_modules/*

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15
+FROM node:16
 
 WORKDIR /client
 

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview --host"
   },
   "dependencies": {
     "@heroicons/vue": "^1.0.1",


### PR DESCRIPTION
@yannic-bruegger ich hab die node version im client von 15 auf 16 angehoben und bei mir läuft docker wieder. Könntest du das einmal verifizieren? 
`docker-compose up --build` um rebuild zu erzwingen